### PR TITLE
String Syntax with Escaped Quote

### DIFF
--- a/syntax/apex.vim
+++ b/syntax/apex.vim
@@ -32,7 +32,7 @@ syn match   apexClassDecl	    "@interface\>"
 syn match   apexBraces          "[{}]"
 syn match   apexKeyword         "[<>]"
 syn match   apexKeyword         "=>"
-syn region  apexString          start=+'+ end=+'+
+syn region  apexString          start=+'+ end=+'+ skip=+\\'+
 syn region  apexSoql            start=+\[+ end=+]+ contains=apexSoqlStatement,apexNumber,apexString,apexSObject
 
 " Comments


### PR DESCRIPTION
Fixes syntax highlighting in strings where you escape the single quote.
