### PR TITLE
Update VF Syntax to Highlight HTML Props with Apex

### DIFF
--- a/syntax/visualforce.vim
+++ b/syntax/visualforce.vim
@@ -10,4 +10,4 @@ runtime! syntax/html.vim
 
 syn keyword htmlTagName        apex contained
 syn keyword htmlTagName        c contained
-syn match   htmlSpecialChar    "{!.*}" contained contains=htmlString
+syn region   htmlSpecialChar    start=+{!+ end=+}+ 


### PR DESCRIPTION
Syntax highlighting where an html tag property contained an Apex value
was thrown off. This allows proper identification of an Apex tag and
hightlights it as a special character anywhere in the page.

The only thing here I'm not sure about is if there would be any adverse effects to not limiting this to a "contained" syn value. If this is borking down the road it can be added back.

Example of code causing problems:

```
<table>
  <tr>
    <td class="{!foo.bar}">foo</td>
    <td class="foo">bar</td>
  </tr>
</table>
```
