### PR TITLE
Add tag support for tagbar and tlist

### DIFF
--- a/plugin/forcedotcom.vim
+++ b/plugin/forcedotcom.vim
@@ -1,0 +1,26 @@
+" Tag support for Apex by using c# settings
+let g:tlist_apex_settings = 'c#;' .
+    \ 'f:field;' .
+    \ 'p:property;' .
+    \ 'i:interface;' .
+    \ 'c:class;' .
+    \ 'm:method'
+
+let g:tagbar_type_apex = {
+    \ 'ctagstype' : 'c#',
+    \ 'kinds' : [
+        \ 'f:fields',
+        \ 'p:properties',
+        \ 'g:enum types',
+        \ 'e:enum constants',
+        \ 'i:interfaces',
+        \ 'c:classes',
+        \ 'm:methods'
+    \],
+    \ 'kind2scope' : {
+        \ 'g' : 'enum',
+        \ 'i' : 'interface',
+        \ 'c' : 'class'
+    \},
+    \ 'sro' : '.'
+\ }


### PR DESCRIPTION
Also curious on your opinion @couchand. Since we seem to be the most involved in committing.

If this is a plugin offering Force.com support to vim, does it make sense to include other files that involve support for different plugins as well as the syntax we've already included?

It's also just kind of a hack anyway. Using C# instead of Java because ctags doesn't recognize the get/set auto property syntax without using C#. Thought of compiling a fork of ctags, but that'd be a waste since nobody would install it.
