### PR TITLE
Add an new match syntax for 'new'

### DIFF
--- a/syntax/apex.vim
+++ b/syntax/apex.vim
@@ -21,7 +21,8 @@ syn keyword apexRepeat          while for do
 syn keyword apexBoolean         true false
 syn keyword apexConstant        null
 syn keyword apexTypedef         this super
-syn keyword apexOperator        new insert update delete upsert
+syn match   apexOperator        "\(\.\)\@<!new"
+syn keyword apexOperator        insert update delete upsert
 syn match   apexEscapeChar      contained "\(\\n\|\\r\|\\t\)"
 syn keyword apexSoqlStatement   contained select where having and or like not in includes excludes from limit group order by asc desc
 syn match   apexSoqlStatement   contained "for\s\+update"


### PR DESCRIPTION
Previous keyword syntax was highlighting every time `new` showed up in
the file. This was annoying for things like `Trigger.new` where `new` is
not functioning as an operator, but rather a normal property.

This patch removes `new` from the `syn keyword` and instead uses `syn
match` to select new only if it does not follow a `.` as in `.new`.
