### PR TITLE
Allow comments to be included within SOQL statements

### DIFF
--- a/syntax/apex.vim
+++ b/syntax/apex.vim
@@ -49,7 +49,7 @@ syn match   apexBraces          "[{}]"
 syn match   apexKeyword         "[<>]"
 syn match   apexKeyword         "=>"
 syn region  apexString          start=+'+ end=+'+ skip=+\\'+ contains=apexEscapeChar
-syn region  apexSoql            start=+\[+ end=+]+ contains=apexSoqlStatement,apexNumber,apexString,apexSObject,apexObject,apexIdentifier,apexConstant
+syn region  apexSoql            start=+\[+ end=+]+ contains=apexSoqlStatement,apexNumber,apexString,apexSObject,apexObject,apexIdentifier,apexConstant,apexComment
 
 syn case match
 


### PR DESCRIPTION
This is technically allowed by SFDC. This fix makes it a bit clearer
when there are comments in your SOQL statements.
