### PR TITLE
Adds *.cmp to list of filetypes for application of Visualforce syntax.

### DIFF
--- a/ftdetect/forcedotcom.vim
+++ b/ftdetect/forcedotcom.vim
@@ -1,4 +1,4 @@
 autocmd BufNewFile,BufRead *.apxc,*.apxt,*.cls,*.trigger,*.tgr set filetype=apex
-autocmd BufNewFile,BufRead *.vfp,*.vfc,*.page,*.component set filetype=visualforce
+autocmd BufNewFile,BufRead *.vfp,*.vfc,*.page,*.component,*.cmp set filetype=visualforce
 autocmd BufNewFile,BufRead *.log set filetype=apexlog
 autocmd BufNewFile,BufRead *.app,*.approvalProcess,*.globalValueSet,*.layout,*.obj,*.object,*.objectTranslation,*.permissionSet,*.tab,*.translation set filetype=xml


### PR DESCRIPTION
Not sure if this is a standard convention in salesforce development, but the organization I've just joined uses the `*.cmp` file extension for their lightning components. So, I've added this extension to the list of detected filetypes for the Visualforce syntax :)